### PR TITLE
Serve static assets with DEBUG disabled

### DIFF
--- a/config/settings.py
+++ b/config/settings.py
@@ -79,6 +79,7 @@ INSTALLED_APPS = [
 
 MIDDLEWARE = [
     "django.middleware.security.SecurityMiddleware",
+    "whitenoise.middleware.WhiteNoiseMiddleware",
     "django.contrib.sessions.middleware.SessionMiddleware",
     "django.middleware.common.CommonMiddleware",
     "django.middleware.csrf.CsrfViewMiddleware",
@@ -355,7 +356,7 @@ INTERNAL_IPS = [
 # Static files (CSS, JavaScript, Images)
 # https://docs.djangoproject.com/en/5.0/howto/static-files/
 
-STATIC_URL = "static/"
+STATIC_URL = "/static/"
 STATICFILES_DIRS = (os.path.join(BASE_DIR, "static"),)
 STATIC_ROOT = os.path.join(BASE_DIR, "staticfiles")
 

--- a/config/tests.py
+++ b/config/tests.py
@@ -1,0 +1,37 @@
+from pathlib import Path
+from tempfile import TemporaryDirectory
+
+from django.conf import settings
+from django.http import HttpResponseNotFound
+from django.test import RequestFactory, SimpleTestCase, override_settings
+from whitenoise.middleware import WhiteNoiseMiddleware
+
+
+class ProductionStaticFilesTests(SimpleTestCase):
+    def test_whitenoise_follows_security_middleware(self):
+        security_middleware = "django.middleware.security.SecurityMiddleware"
+        whitenoise_middleware = "whitenoise.middleware.WhiteNoiseMiddleware"
+        security_index = settings.MIDDLEWARE.index(security_middleware)
+
+        self.assertEqual(settings.MIDDLEWARE[security_index + 1], whitenoise_middleware)
+
+    def test_whitenoise_serves_collected_static_file_with_debug_disabled(self):
+        with TemporaryDirectory() as static_root:
+            stylesheet = Path(static_root) / "css" / "test.css"
+            stylesheet.parent.mkdir(parents=True)
+            stylesheet.write_text("body { color: black; }", encoding="utf-8")
+
+            with override_settings(DEBUG=False, STATIC_ROOT=static_root):
+                middleware = WhiteNoiseMiddleware(
+                    lambda request: HttpResponseNotFound()
+                )
+                request = RequestFactory().get("/static/css/test.css")
+                response = middleware(request)
+
+                try:
+                    content = b"".join(response.streaming_content)
+                finally:
+                    response.close()
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(content, b"body { color: black; }")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,6 +8,7 @@ readme = "README.md"
 license = "MIT"
 dependencies = [
     "django>=5.0.6,<6",
+    "whitenoise>=6.12.0,<7",
     "django-htmx>=1.17.3,<2",
     "django-environ>=0.11.2,<0.12",
     "django-tailwind>=3.8.0,<4",

--- a/uv.lock
+++ b/uv.lock
@@ -201,6 +201,7 @@ dependencies = [
     { name = "requests" },
     { name = "taggit-selectize" },
     { name = "wagtail" },
+    { name = "whitenoise" },
 ]
 
 [package.dev-dependencies]
@@ -240,6 +241,7 @@ requires-dist = [
     { name = "requests", specifier = ">=2.32.3,<3" },
     { name = "taggit-selectize", specifier = ">=2.11.0,<3" },
     { name = "wagtail", specifier = "~=6.1" },
+    { name = "whitenoise", specifier = ">=6.12.0,<7" },
 ]
 
 [package.metadata.requires-dev]
@@ -1130,6 +1132,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/0b/02/ae6ceac1baeda530866a85075641cec12989bd8d31af6d5ab4a3e8c92f47/webencodings-0.5.1.tar.gz", hash = "sha256:b36a1c245f2d304965eb4e0a82848379241dc04b865afcc4aab16748587e1923", size = 9721, upload-time = "2017-04-05T20:21:34.189Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/f4/24/2a3e3df732393fed8b3ebf2ec078f05546de641fe1b667ee316ec1dcf3b7/webencodings-0.5.1-py2.py3-none-any.whl", hash = "sha256:a0af1213f3c2226497a97e2b3aa01a7e4bee4f403f95be16fc9acd2947514a78", size = 11774, upload-time = "2017-04-05T20:21:32.581Z" },
+]
+
+[[package]]
+name = "whitenoise"
+version = "6.12.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/cb/2a/55b3f3a4ec326cd077c1c3defeee656b9298372a69229134d930151acd01/whitenoise-6.12.0.tar.gz", hash = "sha256:f723ebb76a112e98816ff80fcea0a6c9b8ecde835f8ddda25df7a30a3c2db6ad", size = 26841, upload-time = "2026-02-27T00:05:42.028Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/db/eb/d5583a11486211f3ebd4b385545ae787f32363d453c19fffd81106c9c138/whitenoise-6.12.0-py3-none-any.whl", hash = "sha256:fc5e8c572e33ebf24795b47b6a7da8da3c00cff2349f5b04c02f28d0cc5a3cc2", size = 20302, upload-time = "2026-02-27T00:05:40.086Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- add WhiteNoise as a production dependency
- serve collected static files when `DEBUG=False`
- use an explicit root-relative `/static/` URL
- add regression coverage for middleware ordering and production static responses

## Testing

- `DEBUG=False DJANGO_ALLOWED_HOSTS=localhost .venv/bin/python manage.py check`
- `DEBUG=False DJANGO_ALLOWED_HOSTS=localhost .venv/bin/python manage.py collectstatic --no-input --verbosity 1`
- verified HTTP 200 responses for project CSS, JavaScript, and Font Awesome assets with `DEBUG=False`
- `DEBUG=False DJANGO_ALLOWED_HOSTS=localhost .venv/bin/python manage.py test config.tests --verbosity 2`
- `.venv/bin/black --check config/tests.py`
- `uv lock --check`

The full database-backed suite could not run locally because the configured PostgreSQL user cannot create a test database and Docker was unavailable. The focused database-free regression suite passes.
